### PR TITLE
mark-devkit: Bump net-wireless/bluez-5.82-r1

### DIFF
--- a/net-wireless/bluez/bluez-5.82-r1.ebuild
+++ b/net-wireless/bluez/bluez-5.82-r1.ebuild
@@ -37,10 +37,10 @@ BDEPEND="
 "
 DEPEND="
 	>=dev-libs/glib-2.28:2[${MULTILIB_USEDEP}]
-	btpclient? ( ~dev-libs/ell-0.76 )
+	btpclient? ( ~dev-libs/ell-0.77 )
 	cups? ( net-print/cups:= )
 	mesh? (
-		~dev-libs/ell-0.76
+		~dev-libs/ell-0.77
 		>=dev-libs/json-c-0.13:=
 		sys-libs/readline:0=
 	)


### PR DESCRIPTION
Automatic bump of package net-wireless/bluez-5.82-r1 for branch mark-iii by mark-bot