### PR TITLE
mark-devkit: Bump net-wireless/irda-utils-0.9.18-r7

### DIFF
--- a/net-wireless/irda-utils/irda-utils-0.9.18-r7.ebuild
+++ b/net-wireless/irda-utils/irda-utils-0.9.18-r7.ebuild
@@ -1,3 +1,4 @@
+# Copyright 1999-2017 Gentoo Foundation
 # Distributed under the terms of the GNU General Public License v2
 
 EAPI=5
@@ -35,14 +36,11 @@ PATCHES=(
 	"${FILESDIR}/${P}-asneeded.patch"
 	"${FILESDIR}/${P}-ldflags.patch"
 	"${FILESDIR}/${P}-headers.patch"
-	"${FILESDIR}"/irdadump.patch
 )
 
 src_prepare() {
 	# TODO: switch to 'default' once udev.eclass is EAPI=6 clean
 	epatch -p1 "${PATCHES[@]}"
-
-	epatch_user
 
 	append-flags "-fno-strict-aliasing" # bug????
 


### PR DESCRIPTION
Automatic bump of package net-wireless/irda-utils-0.9.18-r7 for branch mark-iii by mark-bot